### PR TITLE
Column name override changes

### DIFF
--- a/ActiveRecord/Structs.tt
+++ b/ActiveRecord/Structs.tt
@@ -39,7 +39,8 @@
 	                IsNullable = <#=col.IsNullable.ToString().ToLower()#>,
 	                AutoIncrement = <#=col.AutoIncrement.ToString().ToLower()#>,
 	                IsForeignKey = <#=col.IsForeignKey.ToString().ToLower()#>,
-	                MaxLength = <#=col.MaxLength#>
+	                MaxLength = <#=col.MaxLength#>,
+					PropertyName = "<#=col.Name#>"
                 });
 <#          }#>                    
                 

--- a/ActiveRecord/Structs.tt
+++ b/ActiveRecord/Structs.tt
@@ -40,7 +40,7 @@
 	                AutoIncrement = <#=col.AutoIncrement.ToString().ToLower()#>,
 	                IsForeignKey = <#=col.IsForeignKey.ToString().ToLower()#>,
 	                MaxLength = <#=col.MaxLength#>,
-					PropertyName = "<#=col.Name#>"
+						PropertyName = "<#=col.Name#>"
                 });
 <#          }#>                    
                 

--- a/LinqTemplates/Structs.tt
+++ b/LinqTemplates/Structs.tt
@@ -36,7 +36,8 @@ namespace <#=Namespace#> {
 	                IsNullable = <#=col.IsNullable.ToString().ToLower()#>,
 	                AutoIncrement = <#=col.AutoIncrement.ToString().ToLower()#>,
 	                IsForeignKey = <#=col.IsForeignKey.ToString().ToLower()#>,
-	                MaxLength = <#=col.MaxLength#>
+	                MaxLength = <#=col.MaxLength#>,
+					PropertyName = "<#=col.Name#>"
                 });
 <#          }#>                    
                 

--- a/LinqTemplates/Structs.tt
+++ b/LinqTemplates/Structs.tt
@@ -37,7 +37,7 @@ namespace <#=Namespace#> {
 	                AutoIncrement = <#=col.AutoIncrement.ToString().ToLower()#>,
 	                IsForeignKey = <#=col.IsForeignKey.ToString().ToLower()#>,
 	                MaxLength = <#=col.MaxLength#>,
-					PropertyName = "<#=col.Name#>"
+						PropertyName = "<#=col.Name#>"
                 });
 <#          }#>                    
                 

--- a/SubSonic.TemplatesVB/ActiveRecord/Structs.tt
+++ b/SubSonic.TemplatesVB/ActiveRecord/Structs.tt
@@ -35,7 +35,7 @@ NameSpace <#=Namespace#>
 					.DataType = DbType.<#=col.DbType.ToString()#>, _
 					.IsNullable = <#=col.IsNullable.ToString().ToLower()#>, _
 					.AutoIncrement = <#=col.AutoIncrement.ToString().ToLower()#>, _
-					.IsForeignKey = <#=col.IsForeignKey.ToString().ToLower()#> _
+					.IsForeignKey = <#=col.IsForeignKey.ToString().ToLower()#>, _
 					.PropertyName = "<#=col.Name#>" _
 				})
 

--- a/SubSonic.TemplatesVB/ActiveRecord/Structs.tt
+++ b/SubSonic.TemplatesVB/ActiveRecord/Structs.tt
@@ -36,6 +36,7 @@ NameSpace <#=Namespace#>
 					.IsNullable = <#=col.IsNullable.ToString().ToLower()#>, _
 					.AutoIncrement = <#=col.AutoIncrement.ToString().ToLower()#>, _
 					.IsForeignKey = <#=col.IsForeignKey.ToString().ToLower()#> _
+					.PropertyName = "<#=col.Name#>" _
 				})
 
 <#          }#>                    


### PR DESCRIPTION
These changes support the column name override change on col-override branch in core subsonic. This should allow Linq and Active record to work properly with the change. 
